### PR TITLE
Implement OpenID Connect with the use of mozilla-django-oidc

### DIFF
--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -83,10 +83,13 @@
             <div id="navbar" class="navbar-collapse collapse">
               <ul class="nav navbar-nav navbar-right">
                 <li><a href="{% url 'home' %}"><span class="glyphicon glyphicon-home" aria-hidden="true"></span></a></li>
-                {% if user.is_authenticated and user.is_staff %}
-                  <li><a href="{% url 'admin:index' %}">Admin Console</a></li>
+                {% if user.is_authenticated %}
+                  <li>{{ user.username }}</li>
+                  {% if user.is_staff %}
+                    <li><a href="{% url 'admin:index' %}">Admin Console</a></li>
+                  {% endif %}
                 {% else %}
-                  <li><a href="{% url 'admin:index' %}">Admin Login</a></li>
+                  <li><a href="{% url 'oidc_authentication_init' %}">Login</a></li>
                 {% endif %}
                 <li><a href="{% url 'settings' %}">Inventory and Configuration</a></li>
                 <li><a href="{% url 'howto' %}">How to use {{ app_name }}</a></li>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,3 +13,4 @@ requests==2.11.1
 smmap2==2.0.2
 sqlparse==0.2.2
 Unidecode==0.4.19
+mozilla-django-oidc

--- a/transtats/settings/base.py
+++ b/transtats/settings/base.py
@@ -110,6 +110,8 @@ SESSION_COOKIE_SECURE = False
 
 WSGI_APPLICATION = 'transtats.wsgi.application'
 
+LOGIN_REDIRECT_URL = '/'
+
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases

--- a/transtats/settings/dev.py
+++ b/transtats/settings/dev.py
@@ -16,6 +16,19 @@ from .base import *
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+# OpenID Connect
+# NOTE: This client ID only works on localhost:8080.
+INSTALLED_APPS += ('mozilla_django_oidc', )
+AUTHENTICATION_BACKENDS += ('transtats.utils.TranstateOIDCBackend', )
+OIDC_RP_CLIENT_ID = 'transtatsdev'
+OIDC_RP_CLIENT_SECRET = 'uvwFVN7SNgmNCQVJTR9QdrkMginl0RM4'
+OIDC_OP_AUTHORIZATION_ENDPOINT = 'https://iddev.fedorainfracloud.org/openidc/Authorization'
+OIDC_OP_TOKEN_ENDPOINT = 'https://iddev.fedorainfracloud.org/openidc/Token'
+OIDC_OP_USER_ENDPOINT = 'https://iddev.fedorainfracloud.org/openidc/UserInfo'
+OIDC_RP_SIGN_ALGO = 'RS256'
+OIDC_RP_IDP_SIGN_KEY = {"use": "sig", "kid": "1462960685-sig", "e": "AQAB", "kty": "RSA", "n": "q_0_XjILQxF3OaQZtFE3wVJ5UUuxZbxiJ_z-Zai0EOHiaMMxVyooibDRen615r525DQ8TmQyR0eMQEpQ6SUvaOunahpYohgAkbkYggUMQhcoCLme18ZJBTNWTP8w4t7mcuZd1cy1KtHpEvH4gkrjp8N3vIv1lzFraSc-p2rHMbV-AX5CJQ1HohBdwaqyOBKp0nzY27gu2EH2vzCwXkO4zGtrHfjjGc0Ra4WG-xz1AWg833xcFj3pqM3vca09jDLBme-GT151LcCCXRNyOZPZ3ZX62NxkMyqvVJHC3Uu2Q1hSHO7f6AZkZXY88PXXEH52T2ZrWiISowjTcGUboP8goQ"}
+
+
 # Email Backend
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/transtats/urls.py
+++ b/transtats/urls.py
@@ -25,6 +25,7 @@ admin.site.site_title = 'Transtats Admin'
 urlpatterns = [
     url(r'^', include('dashboard.urls')),
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^oidc/', include('mozilla_django_oidc.urls')),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG:

--- a/transtats/utils.py
+++ b/transtats/utils.py
@@ -1,0 +1,19 @@
+"""
+Some base utilities/classes.
+"""
+
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+
+
+class TranstateOIDCBackend(OIDCAuthenticationBackend):
+    def filter_users_by_claims(self, claims):
+        """Find users by matching username=sub."""
+        # The claims.get and None-case were dropped, since if there is no sub,
+        # the OpenID Connect specification was broken.
+        return self.UserModel.objects.filter(username=claims['sub'])
+
+    def create_user(self, claims):
+        """ Create a new user from the retrieved claims. """
+        email = claims.get('email')
+
+        return self.UserModel.objects.create_user(claims['sub'], email=email)


### PR DESCRIPTION
Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
Implement OpenID Connect authentication for use in Fedora Infrastructure.
Added dependency on mozilla-django-oidc.

Note that for the Fedora Identity Provider, this needs https://github.com/mozilla/mozilla-django-oidc/pull/161.
Otherwise the logs are going to show a 500 on /oidc/callback/?state=...&code=...