### PR TITLE
Use fixture module to build test database

### DIFF
--- a/dashboard/tests/test_inventory.py
+++ b/dashboard/tests/test_inventory.py
@@ -13,67 +13,22 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from django.test import TestCase
+from fixture import DjangoFixture
+from fixture.style import NamedDataStyle
+from fixture.django_testcase import FixtureTestCase
 from dashboard.managers.inventory import InventoryManager
-from dashboard.models import Languages, LanguageSet, TransPlatform, ReleaseStream, StreamBranches
-from dashboard.constants import RELSTREAM_SLUGS
+from dashboard.models import ReleaseStream
+from dashboard.tests.testdata.db_fixtures import (LanguagesData, LanguageSetData, TransPlatformData, ReleaseStreamData,
+                                                  StreamBranchesData)
+
+db_fixture = DjangoFixture(style=NamedDataStyle())
 
 
-class InventoryTest(TestCase):
+class InventoryManagerTest(FixtureTestCase):
 
     inventory_manager = InventoryManager()
-
-    def setUp(self):
-        """
-        Lets dump some test data in db
-        """
-        Languages.objects.update_or_create(
-            locale_id='ja_JP', lang_name='Japanese', locale_alias='ja', lang_status=True
-        )
-
-        Languages.objects.update_or_create(
-            locale_id='fr_FR', lang_name='French', locale_alias='fr', lang_status=False
-        )
-
-        Languages.objects.update_or_create(
-            locale_id='ru_RU', lang_name='Russian', locale_alias='ru', lang_status=True
-        )
-
-        Languages.objects.update_or_create(
-            locale_id='ko_KR', lang_name='Korean', locale_alias='ko', lang_status=True
-        )
-
-        LanguageSet.objects.update_or_create(
-            lang_set_name='Custom Set', lang_set_slug='custom-set', lang_set_color='Peru',
-            locale_ids=['fr_FR', 'ja_JP']
-        )
-
-        LanguageSet.objects.update_or_create(
-            lang_set_name='F27 Set', lang_set_slug='f27-set', lang_set_color='Green',
-            locale_ids=['ja_JP', 'fr_FR', 'ru_RU']
-        )
-
-        TransPlatform.objects.update_or_create(
-            engine_name='zanata', subject='public', api_url='https://translate.zanata.org',
-            platform_slug='ZNTAPUB', server_status=True
-        )
-
-        # todo: specify top_url (if top_url is missing, it should raise error but it doesn't)
-        ReleaseStream.objects.update_or_create(
-            relstream_name='Fedora', relstream_slug=RELSTREAM_SLUGS[1],
-            relstream_server='http://koji.fedoraproject.org/kojihub', relstream_status=True
-        )
-
-        ReleaseStream.objects.update_or_create(
-            relstream_name='RHEL', relstream_slug=RELSTREAM_SLUGS[0],
-            relstream_server='http://companyserver.net/tool', top_url='http://companyserver.net/topdir',
-            relstream_status=False
-        )
-
-        StreamBranches.objects.update_or_create(
-            relbranch_name='Fedora 27', relbranch_slug='fedora-27', relstream_slug=RELSTREAM_SLUGS[1],
-            lang_set='f27-set', created_on='2017-10-30 00:00+05:30', sync_calendar=False
-        )
+    fixture = db_fixture
+    datasets = [LanguagesData, LanguageSetData, TransPlatformData, ReleaseStreamData, StreamBranchesData]
 
     def test_get_locales(self):
         """

--- a/dashboard/tests/testdata/db_fixtures.py
+++ b/dashboard/tests/testdata/db_fixtures.py
@@ -1,0 +1,109 @@
+# Copyright 2017 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# This file contains fixture data used for tests
+
+from fixture import DataSet
+from dashboard.constants import RELSTREAM_SLUGS
+
+
+class LanguagesData(DataSet):
+    class Meta:
+        django_model = 'dashboard.Languages'
+
+    class lang_ja:
+        locale_id = 'ja_JP'
+        lang_name = 'Japanese'
+        locale_alias = 'ja'
+        lang_status = True
+
+    class lang_fr:
+        locale_id = 'fr_FR'
+        lang_name = 'French'
+        locale_alias = 'fr'
+        lang_status = False
+
+    class lang_ru:
+        locale_id = 'ru_RU'
+        lang_name = 'Russian'
+        locale_alias = 'ru'
+        lang_status = True
+
+    class lang_ko:
+        locale_id = 'ko_KR'
+        lang_name = 'Korean'
+        locale_alias = 'ko'
+        lang_status = True
+
+
+class LanguageSetData(DataSet):
+    class Meta:
+        django_model = 'dashboard.LanguageSet'
+
+    class lang_set_custom:
+        lang_set_name = 'Custom Set'
+        lang_set_slug = 'custom-set'
+        lang_set_color = 'Peru'
+        locale_ids = ['fr_FR', 'ja_JP']
+
+    class lang_set_f27:
+        lang_set_name = 'F27 Set'
+        lang_set_slug = 'f27-set'
+        lang_set_color = 'Green'
+        locale_ids = ['ja_JP', 'fr_FR', 'ru_RU']
+
+
+class TransPlatformData(DataSet):
+    class Meta:
+        django_model = 'dashboard.TransPlatform'
+
+    class platform_zanata:
+        engine_name = 'zanata'
+        subject = 'public'
+        api_url = 'https://translate.zanata.org'
+        platform_slug = 'ZNTAPUB'
+        server_status = True
+
+
+class ReleaseStreamData(DataSet):
+    class Meta:
+        django_model = 'dashboard.ReleaseStream'
+
+    class relstream_fedora:
+        relstream_name = 'Fedora'
+        relstream_slug = RELSTREAM_SLUGS[1]
+        relstream_server = 'http://koji.fedoraproject.org/kojihub'
+        top_url = 'https://kojipkgs.fedoraproject.org'
+        relstream_status = True
+
+    class relstream_rhel:
+        relstream_name = 'RHEL'
+        relstream_slug = RELSTREAM_SLUGS[0]
+        relstream_server = 'http://companyserver.net/tool'
+        top_url = 'http://companyserver.net/topdir'
+        relstream_status = False
+
+
+class StreamBranchesData(DataSet):
+    class Meta:
+        django_model = 'dashboard.StreamBranches'
+
+    class streambranch_f27:
+        relbranch_name = 'Fedora 27'
+        relbranch_slug = 'fedora-27'
+        relstream_slug = RELSTREAM_SLUGS[1]
+        lang_set = 'f27-set'
+        created_on = '2017-10-30 00:00+05:30'
+        sync_calendar = False

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -3,3 +3,4 @@ flake8==3.2.0
 mccabe==0.5.2
 pycodestyle==2.2.0
 pyflakes==1.3.0
+fixture==1.5.11


### PR DESCRIPTION
Using this module makes it easy to build test database, saves the hassle of dealing with `yml` or `JSON` for fixture. 
Also it makes it easy to build test database if the tables have foreign keys in them
http://farmdev.com/projects/fixture/using-fixture-with-django.htm


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### SUMMARY

Issue #77 